### PR TITLE
Feat: Add a variable to control whether face-today is applied

### DIFF
--- a/calfw-blocks.el
+++ b/calfw-blocks.el
@@ -1029,6 +1029,9 @@ is added at the beginning of a block to indicate it is the beginning."
            (push overlay ols)))))
     (setf (cfw:dest-today-ol dest) ols)))
 
+(defvar cfw:highlight-today t
+  "Variable to control whether today is rendered differently than other days.")
+
 (defun cfw:cp-update (component)
   "[internal] Clear and re-draw the component content."
   (let* ((buf (cfw:cp-get-buffer component))
@@ -1045,7 +1048,7 @@ is added at the beginning of a block to indicate it is the beginning."
                                        component)))
       (if (eq (cfw:component-view component) 'block-week)
           (calfw-blocks-dest-ol-today-set dest)
-      (cfw:dest-ol-today-set dest))
+        (when cfw:highlight-today (cfw:dest-ol-today-set dest)))
       (cfw:cp-set-selected-date
        component (cfw:component-selected component))
       (cfw:dest-after-update dest)


### PR DESCRIPTION
This variable gives me control on whether `cfw:face-today` is applied to the whole day view or not. This is important because I actually prefer the colors that `calfw-blocks` uses for rendering the calendar than the default used by `emacs-calfw`, and setting the new `cfw:hightlight-today` to nil lets me use it so.

This change has also been contributed back to `emacs-calfw` at: kiwanami/emacs-calfw#154