### PR TITLE
Modernize loops and avoid obsolete overlay clearing

### DIFF
--- a/calfw-blocks.el
+++ b/calfw-blocks.el
@@ -1379,14 +1379,13 @@ is added at the beginning of a block to indicate it is the beginning."
          (dest (cfw:component-dest component)))
     (with-current-buffer buf
       (cfw:dest-before-update dest)
-      (cfw:dest-ol-selection-clear dest)
       (cfw:dest-ol-today-clear dest)
       (let ((buffer-read-only nil))
         (cfw:dest-with-region dest
-                              (cfw:dest-clear dest)
-                              (funcall (cfw:cp-dispatch-view-impl
-                                        (cfw:component-view component))
-                                       component)))
+          (cfw:dest-clear dest)
+          (funcall (cfw:cp-dispatch-view-impl
+                    (cfw:component-view component))
+                   component)))
       (if (eq (cfw:component-view component) 'block-week)
           (calfw-blocks-dest-ol-today-set dest)
         (when cfw:highlight-today (cfw:dest-ol-today-set dest)))

--- a/calfw-blocks.el
+++ b/calfw-blocks.el
@@ -178,7 +178,7 @@ VIEW is a symbol of the view type."
      `((eol . ,EOL) (vl . ,(cfw:rt (make-string 1 cfw:fchar-vertical-line) 'cfw:face-grid))
        (hline . ,(cfw:rt
                   (concat
-                   (loop for i from 0 below 2 concat
+                   (cl-loop for i from 0 below 2 concat
                          (concat
                           (make-string 1 (if (= i 0) cfw:fchar-top-left-corner cfw:fchar-top-junction))
                           (make-string num-date-cell-char cfw:fchar-horizontal-line)
@@ -189,7 +189,7 @@ VIEW is a symbol of the view type."
                   'cfw:face-grid))
        (cline . ,(cfw:rt
                   (concat
-                   (loop for i from 0 below 2 concat
+                   (cl-loop for i from 0 below 2 concat
                          (concat
                           (make-string 1 (if (= i 0) cfw:fchar-left-junction cfw:fchar-junction))
                           (make-string num-date-cell-char cfw:fchar-horizontal-line)
@@ -272,7 +272,7 @@ return an alist of rendering parameters."
                                              days content-fun do-weeks)
   "[internal] Insert calendar cells for the linear views."
   (calfw-blocks-render-columns-transpose
-   (loop with cell-width      = (cfw:k 'cell-width param)
+   (cl-loop with cell-width      = (cfw:k 'cell-width param)
          with days            = (or days (cfw:k 'days model))
          with content-fun     = (or content-fun
                                     'cfw:render-event-days-overview-content)
@@ -319,7 +319,7 @@ return an alist of rendering parameters."
   (when periods-stack
     (let ((stack (sort (copy-sequence periods-stack)
                        (lambda (a b) (< (car a) (car b))))))
-      (loop for (row (begin end content props interval)) in stack
+      (cl-loop for (row (begin end content props interval)) in stack
             for beginp = (equal date begin)
             for endp = (equal date end)
             for width = (- cell-width 2)
@@ -350,19 +350,19 @@ DAY-COLUMNS is a list of columns. A column is a list of following form: (DATE (D
          (num-days (length day-columns))
          (first-half (seq-subseq day-columns 0 (/ num-days 2)))
          (second-half (seq-subseq day-columns (/ num-days 2) num-days)))
-    (loop for j from 0 below (/ num-days 2)
+    (cl-loop for j from 0 below (/ num-days 2)
           for day1 = (nth j first-half)
           for day2 = (nth j second-half)
           do
-          (loop with breaked-day-columns =
-                (loop for day-rows in `(,day1 ,day2)
+          (cl-loop with breaked-day-columns =
+                (cl-loop for day-rows in `(,day1 ,day2)
                       for date = (car day-rows)
                       for line = (cddr day-rows)
                       collect
                       (cons date (cfw:render-break-lines
                                   line cell-width cell-height)))
                 with breaked-date-columns =
-                (loop for day-rows in `(,day1 ,day2)
+                (cl-loop for day-rows in `(,day1 ,day2)
                       for date = (car day-rows)
                       for dayname = (aref calendar-day-name-array
                                           (calendar-day-of-week date))
@@ -386,7 +386,7 @@ DAY-COLUMNS is a list of columns. A column is a list of following form: (DATE (D
                                        (length (cdr (nth 1 breaked-date-columns))))
                 for i from 1 to max-height
                 do
-                (loop for k from 0 to 1
+                (cl-loop for k from 0 to 1
                       for day-rows = (nth k breaked-day-columns)
                       for date-rows = (nth k breaked-date-columns)
                       for date = (car day-rows)


### PR DESCRIPTION
## Summary

- Replace obsolete `loop` usages with `cl-loop`.
- Remove the call to obsolete `cfw:dest-ol-selection-clear`.
- Keep rendering behavior unchanged while avoiding obsolete API usage on newer Emacs/calfw versions.

## Notes

This is a small compatibility cleanup. The rendering update still clears and redraws the destination region, and today highlighting remains handled by the existing today overlay code.
